### PR TITLE
small fixes

### DIFF
--- a/fast_response/GWFollowup.py
+++ b/fast_response/GWFollowup.py
@@ -163,7 +163,7 @@ class GWFollowup(PriorFollowup):
 
         t1 = Time(datetime.datetime.utcnow()).mjd
         if ((t1-self.stop)*86400.)>5000.:
-            #if it's been long enough, only load 1000s
+            #if it's been long enough, only load 2000s
             print('Loading 2000s of data after the time window')
             t1 = self.stop + 2000./86400. 
         exp_long, livetime_long, grl_long = self.dset.livestream(
@@ -179,6 +179,9 @@ class GWFollowup(PriorFollowup):
         if exp_long[mask].size > 0:
             check_passed = True
             print('Found {} events after end of time window'.format(exp_long[mask].size))
+        # elif Time(datetime.datetime.utcnow()).mjd > (self.stop + 5000./86400.):
+        #     raise Exception('No events found 2000 seconds after GW event.')
+        
         return check_passed
 
     def initialize_llh(self, skipped=None, scramble=False):
@@ -209,10 +212,14 @@ class GWFollowup(PriorFollowup):
             dset = Datasets[self.dataset]
             self.dset = dset
             check_passed = False
-            print('Checking for events after time window')
+            if self.stop < 59215: 
+                print('Old times: Skipping check for events after time window')
+                check_passed = True
+            else:
+                print('Checking for events after time window')
+
             while not check_passed:
                 check_passed = self.check_events_after()
-
             self.get_data()
 
         if self._verbose:


### PR DESCRIPTION
Two small fixes:
* no `check_events_after` if event run is older than 2020 (using archival data) - fixes an error raised when running the example GW followup pointed out by @EvaYYao 
* load rates in two chunks if time window is longer than 45 days (avoid timeout)